### PR TITLE
refactor: move home.backupFileExtension to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,13 @@
             # Apple Silicon specific optimizations
             config.allowUnsupportedSystem = false;
           };
-          modules = [ ./nix/home-manager.nix ];
+          modules = [
+            ./nix/home-manager.nix
+            {
+              # Backup file extension for conflicting files
+              home.backupFileExtension = "backup";
+            }
+          ];
         };
     in
     {
@@ -76,6 +82,8 @@
                   home.username = lib.mkForce username;
                   home.homeDirectory = lib.mkForce "/Users/${username}";
                   home.stateVersion = "24.05";
+                  # Backup file extension for conflicting files
+                  home.backupFileExtension = "backup";
                 };
               }
             )

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -41,9 +41,6 @@
   # Home Manager version
   home.stateVersion = "24.05";
 
-  # Backup file extension for conflicting files
-  home.backupFileExtension = "backup";
-
   # Let Home Manager manage itself
   programs.home-manager.enable = true;
 


### PR DESCRIPTION
Move home.backupFileExtension configuration from nix/home-manager.nix
to flake.nix for centralized configuration management.

- Add home.backupFileExtension to mkHomeConfiguration modules
- Add home.backupFileExtension to darwinConfigurations
- Remove home.backupFileExtension from nix/home-manager.nix

https://claude.ai/code/session_01JjHZFWHU5bddBeZUN2mKPt