### PR TITLE
個人用/業務用プロファイルの分離と禁止ソフトウェアのフィルタリング

### DIFF
--- a/nix/modules/homebrew/default.nix
+++ b/nix/modules/homebrew/default.nix
@@ -2,8 +2,53 @@
   config,
   pkgs,
   lib,
+  profile ? "personal",
   ...
 }:
+
+let
+  # Common casks for both personal and work
+  commonCasks = [
+    # Development tools
+    "ghostty"
+    "iterm2"
+    "visual-studio-code"
+    "android-studio"
+    "xcodes-app"
+    "swiftformat-for-xcode"
+    "claude-code"
+    "claude" # Claude Desktop
+    "font-monaspace"
+
+    # Browsers
+    "google-chrome"
+
+    # Productivity
+    "raycast"
+
+    # Utilities
+    "rectangle" # Window management
+    "the-unarchiver" # Archive utility
+    "google-japanese-ime" # Japanese input method
+  ];
+
+  # Personal-only casks (forbidden for work)
+  personalCasks = [
+    "1password"
+    "notion"
+    "tailscale-app" # VPN/mesh networking
+  ];
+
+  # Work-only casks (can be extended in the future)
+  workCasks = [
+    # Add work-specific applications here if needed
+  ];
+
+  # Select casks based on profile
+  selectedCasks = commonCasks
+    ++ lib.optionals (profile == "personal") personalCasks
+    ++ lib.optionals (profile == "work") workCasks;
+in
 
 {
   # Homebrew configuration for macOS
@@ -44,34 +89,8 @@
     ];
 
     # Homebrew casks (GUI applications)
-    casks = [
-      # Development tools
-      "ghostty"
-      "iterm2"
-      "visual-studio-code"
-      "android-studio"
-      "xcodes-app"
-      "swiftformat-for-xcode"
-      "claude-code"
-      "claude" # Claude Desktop
-      "font-monaspace"
-
-      # Browsers
-      "google-chrome"
-
-      # Productivity
-      "raycast"
-      "1password"
-      "notion"
-
-      # Utilities
-      "rectangle" # Window management
-      "the-unarchiver" # Archive utility
-      "tailscale-app" # VPN/mesh networking
-      "google-japanese-ime" # Japanese input method
-
-      # Add any other casks you need here
-    ];
+    # Automatically filtered based on profile (personal/work)
+    casks = selectedCasks;
 
     # Mac App Store applications
     # Use `mas search <app name>` to find app IDs

--- a/nix/modules/zsh/default.nix
+++ b/nix/modules/zsh/default.nix
@@ -89,24 +89,39 @@
     ];
 
     # Shell aliases (Prezto-style ls aliases using eza)
-    shellAliases = {
-      # ls aliases using eza (modern ls replacement)
-      ls = "eza --icons --git";
-      l = "eza -1 --icons"; # One column
-      la = "eza -lah --icons --git"; # All files, long format
-      ll = "eza -lh --icons --git"; # Long format
-      lt = "eza -lh --icons --git -snew"; # Sort by modified time
-      lr = "eza -lhR --icons --git"; # Recursive
-      tree = "eza --tree --icons"; # Tree view
+    shellAliases = lib.mkMerge [
+      # Common aliases for all platforms
+      {
+        # ls aliases using eza (modern ls replacement)
+        ls = "eza --icons --git";
+        l = "eza -1 --icons"; # One column
+        la = "eza -lah --icons --git"; # All files, long format
+        ll = "eza -lh --icons --git"; # Long format
+        lt = "eza -lh --icons --git -snew"; # Sort by modified time
+        lr = "eza -lhR --icons --git"; # Recursive
+        tree = "eza --tree --icons"; # Tree view
 
-      # Safety aliases
-      rm = "trash-put"; # Use trash instead of rm
+        # Safety aliases
+        rm = "trash-put"; # Use trash instead of rm
 
-      # Other common aliases
-      ".." = "cd ..";
-      "..." = "cd ../..";
-      "...." = "cd ../../..";
-    };
+        # Other common aliases
+        ".." = "cd ..";
+        "..." = "cd ../..";
+        "...." = "cd ../../..";
+      }
+
+      # macOS-specific aliases
+      (lib.mkIf pkgs.stdenv.isDarwin {
+        nixup-p = "sudo darwin-rebuild switch --flake ~/.dotfiles#personal-aarch64-darwin --impure";
+        nixup-w = "sudo darwin-rebuild switch --flake ~/.dotfiles#work-aarch64-darwin --impure";
+      })
+
+      # Linux-specific aliases
+      (lib.mkIf pkgs.stdenv.isLinux {
+        nixup-p = "home-manager switch --flake ~/.dotfiles#personal-$(uname -m)-linux --impure";
+        nixup-w = "home-manager switch --flake ~/.dotfiles#work-$(uname -m)-linux --impure";
+      })
+    ];
 
     # Zsh plugins (replacing Prezto)
     plugins = [


### PR DESCRIPTION
## Summary

個人用マシンと業務用マシンで異なるパッケージセットを使用できるよう、プロファイルシステムを実装しました。業務用プロファイルでは禁止ソフトウェア（1password, notion, tailscale-app）を自動的に除外します。

## Changes

- **flake.nix**: `personal`/`work`プロファイルを受け取るヘルパー関数を追加
  - `mkDarwinConfiguration` と `mkHomeConfiguration` を更新
  - 各プロファイル用の設定を定義（personal-aarch64-darwin, work-aarch64-darwin等）
  - 後方互換性を維持（既存の設定名はpersonalをデフォルト）

- **nix/modules/homebrew/default.nix**: プロファイルに基づくパッケージフィルタリング
  - `commonCasks`: 全プロファイル共通のアプリケーション（14個）
  - `personalCasks`: 個人用のみのアプリケーション（1password, notion, tailscale-app）
  - `workCasks`: 業務用のみのアプリケーション（将来の拡張用）

- **nix/modules/zsh/default.nix**: プラットフォーム対応の便利エイリアスを追加
  - `nixup-p`: 個人用設定を適用
  - `nixup-w`: 業務用設定を適用
  - macOS/Linux両対応

- **CLAUDE.md**: プロファイルシステムのドキュメント追加

## Usage

```bash
# 個人用マシン
nixup-p
# または
sudo darwin-rebuild switch --flake ~/.dotfiles#personal-aarch64-darwin --impure

# 業務用マシン
nixup-w
# または
sudo darwin-rebuild switch --flake ~/.dotfiles#work-aarch64-darwin --impure
```

## Test plan

- [x] `nix flake check` でflake構文チェック
- [x] workプロファイルで禁止パッケージが除外されることを確認
- [x] personalプロファイルで全パッケージが含まれることを確認
- [x] 後方互換性の確認（aarch64-darwinがpersonalをデフォルトとする）
- [x] エイリアスが正しく定義されることを確認
- [x] 実際のマシンで `darwin-rebuild` を実行して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)