### PR TITLE
fix: resolve zsh compinit insecure directories warning

### DIFF
--- a/nix/modules/zsh/default.nix
+++ b/nix/modules/zsh/default.nix
@@ -110,10 +110,11 @@
         "...." = "cd ../../..";
       }
 
-      # macOS-specific aliases
+      # macOS-specific aliases (dynamic architecture detection)
+      # uname -m returns "arm64" on Apple Silicon, "x86_64" on Intel
       (lib.mkIf pkgs.stdenv.isDarwin {
-        nixup-p = "sudo darwin-rebuild switch --flake ~/.dotfiles\\#personal-aarch64-darwin --impure";
-        nixup-w = "sudo darwin-rebuild switch --flake ~/.dotfiles\\#work-aarch64-darwin --impure";
+        nixup-p = "sudo darwin-rebuild switch --flake ~/.dotfiles\\#personal-$(arch=$(uname -m); [ \"$arch\" = \"arm64\" ] && echo aarch64 || echo $arch)-darwin --impure";
+        nixup-w = "sudo darwin-rebuild switch --flake ~/.dotfiles\\#work-$(arch=$(uname -m); [ \"$arch\" = \"arm64\" ] && echo aarch64 || echo $arch)-darwin --impure";
       })
 
       # Linux-specific aliases
@@ -149,5 +150,8 @@
 
     # Enable completion
     enableCompletion = true;
+
+    # Skip insecure directories check (common with Nix-managed completion paths)
+    completionInit = "autoload -U compinit && compinit -u";
   };
 }


### PR DESCRIPTION
## Summary
- zshシェル起動時の`compinit: insecure directories`警告を修正
- nix-darwinの`/etc/zshrc`でのcompinit呼び出しを無効化し、Home Managerに統一
- Intel Mac (x86_64-darwin) サポートを追加
- `nixup-p`/`nixup-w`エイリアスを動的アーキテクチャ検出に対応

## Changes
- `flake.nix`: `programs.zsh.enableCompletion = false`を追加（nix-darwin）
- `nix/modules/zsh/default.nix`: `completionInit`に`-u`フラグを追加

## Background
Nixが管理する補完ディレクトリはzshの厳格なパーミッションチェックを満たさないことがあり、警告が表示されます。`-u`フラグでinsecureディレクトリチェックをスキップすることで解決。

## Test plan
- [x] `nixup-p`または`nixup-w`を実行
- [x] 新しいシェルを開いて警告が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)