### PR TITLE
feat: Work プロファイル用カスタムプロンプトを追加

### DIFF
--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   lib,
+  profile ? "personal",
   ...
 }:
 
@@ -66,15 +67,20 @@
   };
 
   # File management - deploy configuration files
-  home.file = {
-    # Powerlevel10k configuration
-    ".config/zsh/p10k.zsh".source = ./modules/zsh/p10k.zsh;
+  home.file = lib.mkMerge [
+    # Common files for all profiles
+    {
+      # Custom Zsh functions
+      ".config/zsh/functions".source = ./modules/zsh/functions;
 
-    # Custom Zsh functions
-    ".config/zsh/functions".source = ./modules/zsh/functions;
+      # Local Zsh configuration template
+      # Users should copy this to ~/.config/zsh/local.zsh and customize
+      ".config/zsh/local.zsh.template".source = ./modules/zsh/local.zsh.template;
+    }
 
-    # Local Zsh configuration template
-    # Users should copy this to ~/.config/zsh/local.zsh and customize
-    ".config/zsh/local.zsh.template".source = ./modules/zsh/local.zsh.template;
-  };
+    # Personal profile only: Powerlevel10k configuration
+    (lib.mkIf (profile == "personal") {
+      ".config/zsh/p10k.zsh".source = ./modules/zsh/p10k.zsh;
+    })
+  ];
 }


### PR DESCRIPTION
## Summary

- Work プロファイルで Powerlevel10k を使用せず、vcs_info ベースの軽量カスタムプロンプトを使用
- Personal プロファイルは従来の Powerlevel10k を維持

## 変更内容

### カスタムプロンプトの仕様（Work プロファイル）

**表示形式（2行プロンプト）:**
```
~/Projects/my-app git:main+*?↑2↓3
>
```

**表示する情報:**
| 要素 | 記号 | 色 |
|------|------|-----|
| カレントディレクトリ | `%~` | 青 (12) |
| ブランチ名 | `main` | 緑 (10) |
| ステージ済み変更 | `+` | 緑 (10) |
| 未ステージ変更 | `*` | 黄 (11) |
| 未追跡ファイル | `?` | 黄 (11) |
| リモートより先行 | `↑n` | 緑 (10) |
| リモートより遅れ | `↓n` | 赤 (9) |
| プロンプト文字（成功） | `>` | 緑 (10) |
| プロンプト文字（失敗） | `>` | 赤 (9) |
| 現在時刻（右側） | `%*` | グレー (8) |

### 変更ファイル

- `nix/modules/zsh/default.nix`: プロファイルに応じた initContent と plugins の条件分岐
- `nix/home-manager.nix`: p10k.zsh のデプロイを personal プロファイルのみに制限

## Test plan

- [ ] `nixup-w` で Work 設定を適用
- [ ] git リポジトリ外: ディレクトリのみ表示
- [ ] git リポジトリ内: ブランチ名表示
- [ ] ファイル変更: `*` 表示
- [ ] ステージ済み: `+` 表示
- [ ] 未追跡ファイル: `?` 表示
- [ ] `git fetch` 後: `↑n` / `↓n` 表示
- [ ] `false` コマンド後: プロンプト文字が赤色
- [ ] `nixup-p` で Personal 設定を適用し、Powerlevel10k が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)