### PR TITLE
feat: add git-fuzzy-switch and github-fuzzy-switch functions

### DIFF
--- a/nix/modules/git/default.nix
+++ b/nix/modules/git/default.nix
@@ -32,6 +32,10 @@
         ];
       };
 
+      alias = {
+        show-graph = "log --graph --decorate --abbrev-commit --format=format:'%C(blue)%h%C(reset) - %C(green)(%ar)%C(reset)%C(yellow)%d%C(reset)\n  %C(white)%s%C(reset) %C(dim white)- %an%C(reset)'";
+      };
+
       filter.lfs = {
         required = true;
         clean = "git-lfs clean -- %f";

--- a/nix/modules/zsh/functions/github-fuzzy-switch.zsh
+++ b/nix/modules/zsh/functions/github-fuzzy-switch.zsh
@@ -1,0 +1,10 @@
+# gh pr + fzf でPull Requestをインタラクティブにチェックアウトする
+# ref: https://zenn.dev/tenkoma/articles/git-fuzzy-switch
+function github-fuzzy-switch() {
+    local pr_number=$(gh pr list | fzf --height 80% --layout=reverse --preview "echo {} | awk '{print \$1}' | xargs gh pr view" --ansi | awk '{print $1}')
+    if [ -n "$pr_number" ]; then
+        gh pr checkout "$pr_number"
+    fi
+}
+
+alias ghfs="github-fuzzy-switch"


### PR DESCRIPTION
fzfを使ったインタラクティブなブランチ切り替え関数を追加:
- git-fuzzy-switch: ブランチ一覧からfzfで選択してswitch、新規作成にも対応
- github-fuzzy-switch: gh pr listからfzfで選択してPRをcheckout
- git show-graph エイリアスをプレビュー用に追加

ref: https://zenn.dev/tenkoma/articles/git-fuzzy-switch

https://claude.ai/code/session_01QAy54rGPzKHdDz7iNTzwKF