### PR TITLE
fix(lazygit): deltaのpager文字列に--side-by-sideを直接指定

### DIFF
--- a/nix/modules/lazygit/default.nix
+++ b/nix/modules/lazygit/default.nix
@@ -13,8 +13,9 @@
       git = {
         paging = {
           # deltaをpagerとして使用（グローバル設定が引き継がれないため--side-by-sideを直接指定）
+          # lazygit自身がpagingを管理するため--paging=neverでdelta側のpagerを無効化
           colorArg = "always";
-          pager = "delta --dark --side-by-side --pager \"less -RF\"";
+          pager = "delta --dark --side-by-side --paging=never";
         };
       };
     };

--- a/nix/modules/lazygit/default.nix
+++ b/nix/modules/lazygit/default.nix
@@ -15,7 +15,7 @@
           # deltaをpagerとして使用（グローバル設定が引き継がれないため--side-by-sideを直接指定）
           # lazygit自身がpagingを管理するため--paging=neverでdelta側のpagerを無効化
           colorArg = "always";
-          pager = "${pkgs.git-delta}/bin/delta --dark --side-by-side --paging=never";
+          pager = "${pkgs.delta}/bin/delta --dark --side-by-side --paging=never";
         };
       };
     };

--- a/nix/modules/lazygit/default.nix
+++ b/nix/modules/lazygit/default.nix
@@ -15,7 +15,7 @@
           # deltaをpagerとして使用（グローバル設定が引き継がれないため--side-by-sideを直接指定）
           # lazygit自身がpagingを管理するため--paging=neverでdelta側のpagerを無効化
           colorArg = "always";
-          pager = "delta --dark --side-by-side --paging=never";
+          pager = "${pkgs.git-delta}/bin/delta --dark --side-by-side --paging=never";
         };
       };
     };

--- a/nix/modules/lazygit/default.nix
+++ b/nix/modules/lazygit/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ lib, ... }:
 
 {
   programs.lazygit = {
@@ -15,7 +15,7 @@
           # deltaをpagerとして使用（グローバル設定が引き継がれないため--side-by-sideを直接指定）
           # lazygit自身がpagingを管理するため--paging=neverでdelta側のpagerを無効化
           colorArg = "always";
-          pager = "${pkgs.delta}/bin/delta --dark --side-by-side --paging=never";
+          pager = "delta --dark --side-by-side --paging=never";
         };
       };
     };

--- a/nix/modules/lazygit/default.nix
+++ b/nix/modules/lazygit/default.nix
@@ -12,9 +12,9 @@
 
       git = {
         paging = {
-          # deltaをpagerとして使用（side-by-sideはdelta側で設定済み）
+          # deltaをpagerとして使用（グローバル設定が引き継がれないため--side-by-sideを直接指定）
           colorArg = "always";
-          pager = "delta --dark --pager \"less -RF\"";
+          pager = "delta --dark --side-by-side --pager \"less -RF\"";
         };
       };
     };


### PR DESCRIPTION
lazygit経由でdeltaを起動する場合、グローバルのdelta設定
（~/.config/delta/config等）が引き継がれないため、
pager文字列に--side-by-sideオプションを明示的に追加した。

https://claude.ai/code/session_012vJNNA7SFLYttV73LW2g43