### PR TITLE
fix(mise): mise use --global でツール宣言方式に変更

### DIFF
--- a/nix/modules/mise/default.nix
+++ b/nix/modules/mise/default.nix
@@ -1,50 +1,26 @@
 {
-  config,
   pkgs,
   lib,
   ...
 }:
-
-let
-  # mise のグローバル設定内容
-  # ツールを追加・変更する場合はここを編集する
-  miseConfigContent = ''
-    [tools]
-    ruby = "3.4.8"
-    pinact = "latest"
-    firebase = "latest"
-
-    [settings]
-    experimental = true
-  '';
-in
 {
   # mise をインストール（シェル統合を含む）
-  # globalConfig は使用しない（Nix store の読み取り専用シンボリックリンクになり、
-  # mise install / mise use が permission denied になるため）
   programs.mise = {
     enable = true;
   };
 
-  # config.toml を通常の書き込み可能ファイルとしてデプロイする
-  # これにより mise install / mise use が正常に動作する
+  # Nix 管理のツールを mise use --global で宣言する
+  # ファイルの存在チェックなしに毎回実行されるため、ツール追加が確実に反映される
+  # ユーザーが mise use で追加したツールは config.toml に保持される
   home.activation.miseConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    MISE_CONFIG_DIR="${config.xdg.configHome}/mise"
-    MISE_CONFIG_FILE="$MISE_CONFIG_DIR/config.toml"
+    export PATH="${pkgs.mise}/bin:$PATH"
 
-    mkdir -p "$MISE_CONFIG_DIR"
+    if command -v mise &> /dev/null; then
+      # グローバルツールを宣言（既存のユーザー追加ツールは保持される）
+      $DRY_RUN_CMD mise use --global ruby@3.4.8 pinact@latest firebase@latest
 
-    # Nix store へのシンボリックリンクが残っている場合は削除する
-    if [ -L "$MISE_CONFIG_FILE" ]; then
-      rm "$MISE_CONFIG_FILE"
-    fi
-
-    # 通常ファイルが存在しない場合のみ新規作成する
-    # （ユーザーが mise use で追加したツールを保持するため）
-    if [ ! -f "$MISE_CONFIG_FILE" ]; then
-      cat > "$MISE_CONFIG_FILE" << 'MISEEOF'
-    ${miseConfigContent}
-    MISEEOF
+      # settings を設定
+      $DRY_RUN_CMD mise settings set experimental true
     fi
   '';
 


### PR DESCRIPTION
## Summary

- `config.toml` の `if [ ! -f ]` ガードを廃止し、`mise use --global` でツールを毎回宣言する方式に変更
- `nixup-p` のたびに Nix 管理ツール（ruby, pinact, firebase）が確実に反映されるようになる
- ユーザーが `mise use` で追加したツールは引き続き `config.toml` に保持される

## 背景

以前の実装では config.toml が存在する場合はスキップしていたため、後から `pinact` を追加しても `nixup-p` 時に反映されなかった。

## Test plan

- [ ] `nixup-p` 実行後に `mise ls` で全ツール（ruby, pinact, firebase）が表示される
- [ ] `mise install pinact` で正常にインストールされる
- [ ] 既存のユーザー追加ツールが `config.toml` に保持されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)