### PR TITLE
flake.nixにprograms.zsh.histSize = 100000を追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
               # Disable zsh completion in nix-darwin (managed by Home Manager instead)
               # This prevents /etc/zshrc from calling compinit without -u flag
               programs.zsh.enableCompletion = false;
+              programs.zsh.histSize = 100000;
 
               # Primary user for system activation
               # Use SUDO_USER when running with sudo, otherwise fall back to USER


### PR DESCRIPTION
nix-darwinのzsh設定とHome Managerのhistory.size設定の競合を解消するため、
flake.nix側にもhistSizeを明示的に設定。

https://claude.ai/code/session_01H2xh9yDb5D5agLBR1EJS5w