### PR TITLE
fix: sessionVariablesからHISTFILEを削除

### DIFF
--- a/nix/modules/zsh/default.nix
+++ b/nix/modules/zsh/default.nix
@@ -24,8 +24,6 @@
 
     # Session variables
     sessionVariables = {
-      # XDG Base Directory (already set in home.nix, but can override here)
-      HISTFILE = "${config.home.homeDirectory}/.zsh_history";
     };
 
     # Zsh initialization content (replaces initExtra and initExtraBeforeCompInit)


### PR DESCRIPTION
sessionVariablesはexportされるため、子プロセス(copilot cli等)が
HISTFILEを継承し、デフォルトのHISTSIZE(500)で履歴が切り詰められる問題を修正。
HISTFILEはprograms.zsh.history.pathで既に設定されており、exportなしで正しく動作する。

https://claude.ai/code/session_01QgFtqR1zh3eErFuFXYU5ww