### PR TITLE
feat(zsh,claude-code): jenv/git-wt/copilot設定追加、セキュリティdenyルール強化

### DIFF
--- a/nix/modules/claude-code/default.nix
+++ b/nix/modules/claude-code/default.nix
@@ -128,18 +128,34 @@ let
         "mcp__pencil"
       ];
       deny = [
+        # 危険なシェルコマンド
         "Bash(sudo:*)"
-        "Bash(git reset:*)"
-        "Bash(git rebase:*)"
-        "Read(id_rsa)"
-        "Read(id_ed25519)"
-        "Read(**/*token*)"
-        "Read(**/*key*)"
         "Bash(rm -rf:*)"
         "Bash(rm -rf /)"
         "Bash(rm -rf ~)"
         "Bash(rm -rf ~/*)"
         "Bash(rm -rf /*)"
+        "Bash(dd:*)"
+        "Bash(diskutil:*)"
+        "Bash(mkfs:*)"
+        # システム制御
+        "Bash(shutdown:*)"
+        "Bash(reboot:*)"
+        "Bash(kill:*)"
+        "Bash(killall:*)"
+        "Bash(launchctl:*)"
+        # Git の危険な操作
+        "Bash(git reset:*)"
+        "Bash(git rebase:*)"
+        "Bash(git clean:*)"
+        "Bash(git push:*)"
+        # ネットワーク
+        "Bash(nc:*)"
+        # 機密ファイルの読み取り
+        "Read(id_rsa)"
+        "Read(id_ed25519)"
+        "Read(**/*token*)"
+        "Read(**/*key*)"
         "Read(.env)"
         "Read(.env.local)"
         "Read(.env.development)"

--- a/nix/modules/utilities/default.nix
+++ b/nix/modules/utilities/default.nix
@@ -73,9 +73,4 @@
       "--smart-case"
     ];
   };
-
-  # Shell aliases
-  home.shellAliases = {
-    cat = "bat";
-  };
 }

--- a/nix/modules/zsh/default.nix
+++ b/nix/modules/zsh/default.nix
@@ -78,6 +78,41 @@
         zstyle ':completion:*' use-cache on
         zstyle ':completion:*' cache-path "${config.xdg.cacheHome}/zsh/compcache"
 
+        # jenv (Java version manager)
+        export PATH="$HOME/.jenv/bin:$PATH"
+        eval "$(jenv init -)"
+
+        # git-wt (git worktree helper)
+        eval "$(git wt --init zsh)"
+
+        ${lib.optionalString (profile == "work") ''
+          # Copilot CLI (work profile only)
+          # Claude Codeのdeny設定に合わせたツール制限:
+          #   - shell: sudo, rm, git reset, git rebaseを禁止
+          #   - ファイルパターン単位の制限(.env, secret, keyなど)は
+          #     Copilot CLIの仕様上サポートされないため適用不可
+          copilot() {
+            HISTFILE=/dev/null command copilot \
+              --allow-all-tools \
+              --deny-tool='shell(sudo)' \
+              --deny-tool='shell(rm)' \
+              --deny-tool='shell(dd)' \
+              --deny-tool='shell(diskutil)' \
+              --deny-tool='shell(mkfs)' \
+              --deny-tool='shell(shutdown)' \
+              --deny-tool='shell(reboot)' \
+              --deny-tool='shell(kill)' \
+              --deny-tool='shell(killall)' \
+              --deny-tool='shell(launchctl)' \
+              --deny-tool='shell(git reset)' \
+              --deny-tool='shell(git rebase)' \
+              --deny-tool='shell(git clean)' \
+              --deny-tool='shell(git push)' \
+              --deny-tool='shell(nc)' \
+              "$@"
+          }
+        ''}
+
         # Source local config if exists
         [ -f ${config.xdg.configHome}/zsh/local.zsh ] && source ${config.xdg.configHome}/zsh/local.zsh
 

--- a/nix/modules/zsh/local.zsh.template
+++ b/nix/modules/zsh/local.zsh.template
@@ -10,8 +10,3 @@
 
 # Example: Machine-specific aliases
 # alias work='cd ~/work/project'
-
-# Example: Manual tool installations
-# If jenv is installed manually:
-#   export PATH="$HOME/.jenv/bin:$PATH"
-#   eval "$(jenv init -)"


### PR DESCRIPTION
## Summary
- zsh: jenv初期化、git-wt zsh統合、workプロファイル用copilot CLI関数を追加
- claude-code/copilot: 危険なコマンド（dd, diskutil, mkfs, shutdown, reboot, kill, killall, launchctl, git clean, git push, nc）をdenyリストに追加
- utilities: `cat=bat` エイリアスを削除、local.zsh.templateからjenvコメントを削除

## Test plan
- [ ] `nixup-p` でpersonalプロファイルのビルド確認
- [ ] `nixup-w` でworkプロファイルのビルド確認（copilot関数が含まれること）
- [ ] `jenv` コマンドが利用可能であること
- [ ] `git wt` コマンドが利用可能であること
- [ ] `cat` がbatではなくcatとして動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)