### PR TITLE
mobile-dev: zsh PATHからAndroid toolsディレクトリを削除

### DIFF
--- a/nix/modules/mobile-dev/default.nix
+++ b/nix/modules/mobile-dev/default.nix
@@ -30,9 +30,8 @@
     if [[ "$(uname)" == "Darwin" ]]; then
       # macOS-specific
       # Android SDK tools
-      if [ -d "$ANDROID_HOME" ]; then
+      if [ -d "$ANDROID_HOME/platform-tools" ]; then
         export PATH="$ANDROID_HOME/platform-tools:$PATH"
-        export PATH="$ANDROID_HOME/tools:$PATH"
       fi
 
       # Dart pub cache


### PR DESCRIPTION
$ANDROID_HOME/toolsのPATH追加を削除。platform-toolsは残す。

https://claude.ai/code/session_01DQ5w9BybX4x1EmijWehZDH