### PR TITLE
[codex] Add ChatGPT Homebrew cask

### DIFF
--- a/nix/modules/homebrew/default.nix
+++ b/nix/modules/homebrew/default.nix
@@ -27,6 +27,7 @@ let
     "google-chrome"
 
     # Productivity
+    "chatgpt"
     "raycast"
 
     # Utilities


### PR DESCRIPTION
## Summary
- Add the `chatgpt` Homebrew cask to the shared macOS cask list.

## Impact
- Applying the macOS configuration installs the ChatGPT desktop app for both personal and work profiles.

## Validation
- Evaluated the Homebrew module with `nix eval --impure` to confirm the Nix expression parses.