### PR TITLE
[codex] Add Microsoft APM Homebrew package

### DIFF
--- a/nix/modules/homebrew/default.nix
+++ b/nix/modules/homebrew/default.nix
@@ -61,6 +61,7 @@ let
   # Common brews for both personal and work
   commonBrews = [
     # Development tools
+    "microsoft/apm/apm" # Microsoft APM
     "jenv" # Java version manager
     "xcodegen" # Xcode project generator
 
@@ -100,6 +101,7 @@ in
     # as they are now built-in to Homebrew
     taps = [
       "k1LoW/tap" # For git-wt
+      "microsoft/apm" # For Microsoft APM
       # Add any third-party taps you need here
     ];
 


### PR DESCRIPTION
## Summary

- Add the Microsoft APM Homebrew tap.
- Install `microsoft/apm/apm` as a common Homebrew formula for both personal and work profiles.

## Validation

- Ran `nixfmt --check nix/modules/homebrew/default.nix`.